### PR TITLE
chore: add hacktoberfest contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# CONTRIBUTING
+
+Contributions are welcome, and are accepted via pull requests.
+Please review these guidelines before submitting any pull requests.
+
+## Process
+
+1. Fork the project
+1. Create a new branch
+1. Code, test, commit and push
+1. Open a pull request detailing your changes. Make sure your PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+## Guidelines
+
+* Please ensure the coding format by running `mix format`.
+* You may need to [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) to avoid merge conflicts.
+* Please remember that we follow [SemVer](http://semver.org/).
+
+## Setup
+
+Clone your fork, then install the dependencies:
+
+```bash
+mix deps.get
+```
+
+## Format
+
+Format your code:
+```bash
+mix format
+```
+
+## Lint
+
+Lint your code with credo and dialyxir:
+```bash
+mix credo
+mix dialyzer
+```
+
+## Tests
+
+Run all tests:
+```bash
+mix test
+```
+
+## Releasing
+
+The release process of this repository is automated as much as possible to ensure there isn't a bottle neck, or merged PRs waiting to be deployed. Once a PR is merged it into `main`, a secondary PR will be created or updated with a title like so: `chore(main): release <version>`. This PR will include all of the needed changes for a new release, including an updated `CHANGELOG.md` file, increasing the version in `mix.exs`, and updating any documentation. Once a maintainer merged that PR in, a new release will be created in GitHub and pushed to [hex.pm](https://hex.pm/packages/novu).

--- a/README.md
+++ b/README.md
@@ -20,24 +20,8 @@ end
 
 ## Documentation
 
-Documentation is available on [HexDocs](https://hexdocs.pm/novu/readme.html).
+Documentation is generated using `ex_doc` and published to [HexDocs](https://hexdocs.pm/novu/readme.html) on new releases. This is automatic, so our only ask is ensure public functions have proper documentation and examples provided.
 
 ## Contributing
 
-First off, thank you for for showing an interest in contributing to the Elixir SDK for Novu!
-
-### Coding guidelines
-
-To ensure consistency throughout the source code, please ensure all code contributed follows the ELixir formatter rules. These are checked on every PR submitted so you will get warnings if the code is unformatted before it's merged in.
-
-### Documentation
-
-Documentation is generated using `ex_doc` and published to [HexDocs](https://hexdocs.pm/novu/readme.html) on new releases. This is automatic, so our only ask is ensure public functions have proper documentation and examples provided.
-
-### Pull Requests
-
-Pull requests of all kinds are welcome! Before you open a PR, you will want to ensure your PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. This lets us automate SemVer versions for release, as well as generate helpful changelog entries. When a PR is submitted, our GitHub actions will ensure the code compiles and tests pass in the latest versions of Elixir, the code follows formatting rules, as well as credo and dialyzer pass.
-
-### Releasing
-
-The release process of this repository is automated as much as possible to ensure there isn't a bottle neck, or merged PRs waiting to be deployed. Once a PR is merged it into `main`, a secondary PR will be created or updated with a title like so: `chore(main): release <version>`. This PR will include all of the needed changes for a new release, including an updated `CHANGELOG.md` file, increasing the version in `mix.exs`, and updating any documentation. Once a maintainer merged that PR in, a new release will be created in GitHub and pushed to [hex.pm](https://hex.pm/packages/novu).
+First off, thank you for for showing an interest in contributing to the Elixir SDK for Novu! We have created a [contributing guide](./CONTRIBUTING.md) that will show you how to setup a development environment and how to open pull requests.

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Novu.MixProject do
 
   defp package do
     [
-      files: ~w(lib mix.exs CHANGELOG.md README.md LICENSE),
+      files: ~w(lib mix.exs CHANGELOG.md CONTRIBUTING.md README.md LICENSE),
       licenses: ["MIT"],
       links: %{
         Website: "https://novu.co/",
@@ -60,7 +60,11 @@ defmodule Novu.MixProject do
     [
       main: "readme",
       logo: "priv/assets/logo.png",
-      extras: ["CHANGELOG.md", "README.md"]
+      extras: [
+        "README.md": [filename: "readme", title: "Readme"],
+        "CONTRIBUTING.md": [filename: "contributing", title: "Contributing"],
+        "CHANGELOG.md": [filename: "changelog", title: "Changelog"]
+      ]
     ]
   end
 end


### PR DESCRIPTION
This adds some of the requirements for hacktoberfest. Mostly a `CONTRIBUTING.md` file. Updates the readme to point to it, as well as including it in the built documentation. 