### PR TITLE
chore: update CI versions to test against

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,11 +206,12 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-          - elixir: 1.11
-            otp: 23
           - elixir: 1.12
             otp: 24
           - elixir: 1.13
             otp: 25
           - elixir: 1.14
             otp: 25
+          - elixir: 1.15
+            otp: 26
+


### PR DESCRIPTION
Elixir 1.11 is 3 (almost 4) years old. Removes that in favor of a more modern Elixir 1.15 and OTP 26 to test against.