### PR TITLE
feat: add environments module

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,10 @@
+%{
+  configs: [
+    %{
+      name: "default",
+      checks: [
+        {Credo.Check.Readability.SinglePipe, allow_0_arity_functions: true}
+      ]
+    }
+  ]
+}

--- a/lib/novu/environments.ex
+++ b/lib/novu/environments.ex
@@ -1,0 +1,85 @@
+defmodule Novu.Environments do
+  @moduledoc """
+  Provide access to the Novu Environments API
+  """
+
+  alias Novu.Http
+
+  @doc """
+  Retrieve the current environment
+
+  [API Documentation](https://docs.novu.co/api-reference/environments/get-current-environment)
+  """
+  @spec get_current_environment :: Http.response()
+  def get_current_environment do
+    Http.get("/v1/environments/me")
+  end
+
+  @doc """
+  Create a new environment using it's name. Optionally set the parent of the environment to create
+
+  [API Documentation](https://docs.novu.co/api-reference/environments/create-environment)
+  """
+  @spec create_environment(name :: String.t(), opts :: Keyword.t()) :: Http.response()
+  def create_environment(name, opts \\ []) do
+    payload =
+      %{name: name}
+      |> add_optional_value(:parentId, Keyword.get(opts, :parentId))
+
+    Http.post("/v1/environments", payload)
+  end
+
+  @doc """
+  Returns a list of environments
+
+  [API Documentation](https://docs.novu.co/api-reference/environments/get-environments)
+  """
+  @spec get_environments :: Http.response()
+  def get_environments do
+    Http.get("/v1/environments")
+  end
+
+  @doc """
+  Update the environment entity with new information
+
+  [API Documentation](https://docs.novu.co/api-reference/environments/update-env-by-id)
+  """
+  @spec update_environment(environment_id :: String.t(), opts :: Keyword.t()) :: Http.response()
+  def update_environment(environment_id, opts \\ []) do
+    dns =
+      %{}
+      |> add_optional_value(:inboundParseDomain, Keyword.get(opts, :inboundParseDomain))
+
+    payload =
+      %{}
+      |> add_optional_value(:name, Keyword.get(opts, :name))
+      |> add_optional_value(:identifier, Keyword.get(opts, :identifier))
+      |> add_optional_value(:parentId, Keyword.get(opts, :parentId))
+      |> Map.put(:dns, dns)
+
+    Http.put("/v1/environments/#{URI.encode(environment_id)}", payload)
+  end
+
+  @doc """
+  Returns a list of API keys
+
+  [API Documentation](https://docs.novu.co/api-reference/environments/get-api-keys)
+  """
+  @spec get_api_keys :: Http.response()
+  def get_api_keys do
+    Http.get("/v1/environments/api-keys")
+  end
+
+  @doc """
+  Regenerate API keys
+
+  [API Documentation](https://docs.novu.co/api-reference/environments/regenerate-api-keys)
+  """
+  @spec regenerate_api_keys :: Http.response()
+  def regenerate_api_keys do
+    Http.post("/v1/environments/api-keys/regenerate")
+  end
+
+  defp add_optional_value(map, _key, nil), do: map
+  defp add_optional_value(map, key, value), do: Map.put(map, key, value)
+end

--- a/lib/novu/environments.ex
+++ b/lib/novu/environments.ex
@@ -22,7 +22,7 @@ defmodule Novu.Environments do
   """
   @spec create_environment(name :: String.t(), opts :: Keyword.t()) :: Http.response()
   def create_environment(name, opts \\ []) do
-    payload = add_optional_value(%{name: name}, :parentId, Keyword.get(opts, :parentId))
+    payload = add_optional_value(%{name: name}, :parentId, Keyword.get(opts, :parent_id))
     Http.post("/v1/environments", payload)
   end
 
@@ -43,13 +43,13 @@ defmodule Novu.Environments do
   """
   @spec update_environment(environment_id :: String.t(), opts :: Keyword.t()) :: Http.response()
   def update_environment(environment_id, opts \\ []) do
-    dns = add_optional_value(%{}, :inboundParseDomain, Keyword.get(opts, :inboundParseDomain))
+    dns = add_optional_value(%{}, :inboundParseDomain, Keyword.get(opts, :inbound_parse_domain))
 
     payload =
       %{}
       |> add_optional_value(:name, Keyword.get(opts, :name))
       |> add_optional_value(:identifier, Keyword.get(opts, :identifier))
-      |> add_optional_value(:parentId, Keyword.get(opts, :parentId))
+      |> add_optional_value(:parentId, Keyword.get(opts, :parent_id))
       |> Map.put(:dns, dns)
 
     Http.put("/v1/environments/#{URI.encode(environment_id)}", payload)

--- a/lib/novu/environments.ex
+++ b/lib/novu/environments.ex
@@ -22,10 +22,7 @@ defmodule Novu.Environments do
   """
   @spec create_environment(name :: String.t(), opts :: Keyword.t()) :: Http.response()
   def create_environment(name, opts \\ []) do
-    payload =
-      %{name: name}
-      |> add_optional_value(:parentId, Keyword.get(opts, :parentId))
-
+    payload = add_optional_value(%{name: name}, :parentId, Keyword.get(opts, :parentId))
     Http.post("/v1/environments", payload)
   end
 
@@ -46,9 +43,7 @@ defmodule Novu.Environments do
   """
   @spec update_environment(environment_id :: String.t(), opts :: Keyword.t()) :: Http.response()
   def update_environment(environment_id, opts \\ []) do
-    dns =
-      %{}
-      |> add_optional_value(:inboundParseDomain, Keyword.get(opts, :inboundParseDomain))
+    dns = add_optional_value(%{}, :inboundParseDomain, Keyword.get(opts, :inboundParseDomain))
 
     payload =
       %{}
@@ -77,7 +72,7 @@ defmodule Novu.Environments do
   """
   @spec regenerate_api_keys :: Http.response()
   def regenerate_api_keys do
-    Http.post("/v1/environments/api-keys/regenerate")
+    Http.post("/v1/environments/api-keys/regenerate", %{})
   end
 
   defp add_optional_value(map, _key, nil), do: map

--- a/lib/novu/http.ex
+++ b/lib/novu/http.ex
@@ -53,7 +53,7 @@ defmodule Novu.Http do
   Makes a `POST` request to Novu.
   """
   @spec post(url :: Req.url(), body :: map()) :: response()
-  def post(url, body) do
+  def post(url, body \\ %{}) do
     url
     |> build_req()
     |> Req.post!(json: body)

--- a/lib/novu/http.ex
+++ b/lib/novu/http.ex
@@ -53,7 +53,7 @@ defmodule Novu.Http do
   Makes a `POST` request to Novu.
   """
   @spec post(url :: Req.url(), body :: map()) :: response()
-  def post(url, body \\ %{}) do
+  def post(url, body) do
     url
     |> build_req()
     |> Req.post!(json: body)

--- a/test/novu/environments_test.exs
+++ b/test/novu/environments_test.exs
@@ -53,7 +53,7 @@ defmodule Novu.EnvironmentsTest do
         novu_response(conn, 201, %{data: %{data: %{name: name}}})
       end)
 
-      assert {:ok, _body} = Environments.create_environment(name, parentId: parent_id)
+      assert {:ok, _body} = Environments.create_environment(name, parent_id: parent_id)
     end
   end
 
@@ -112,7 +112,7 @@ defmodule Novu.EnvironmentsTest do
         novu_response(conn, 200, %{data: %{data: %{parentId: parent_id}}})
       end)
 
-      assert {:ok, _body} = Environments.update_environment(environment_id, parentId: parent_id)
+      assert {:ok, _body} = Environments.update_environment(environment_id, parent_id: parent_id)
     end
 
     test "supports optional inboundParseDomain", %{bypass: bypass} do
@@ -124,7 +124,7 @@ defmodule Novu.EnvironmentsTest do
         novu_response(conn, 200, %{data: %{data: %{inboundParseDomain: inbound_parse_domain}}})
       end)
 
-      assert {:ok, _body} = Environments.update_environment(environment_id, inboundParseDomain: inbound_parse_domain)
+      assert {:ok, _body} = Environments.update_environment(environment_id, inbound_parse_domain: inbound_parse_domain)
     end
   end
 

--- a/test/novu/environments_test.exs
+++ b/test/novu/environments_test.exs
@@ -1,0 +1,151 @@
+defmodule Novu.EnvironmentsTest do
+  use ExUnit.Case
+
+  import Novu.ApiTestHelpers
+
+  alias Novu.Environments
+
+  @test_api_key "test-api-key"
+
+  setup do
+    bypass = Bypass.open()
+
+    current_domain = Application.get_env(:novu, :domain)
+
+    Application.put_env(:novu, :domain, "http://localhost:#{bypass.port}")
+    Application.put_env(:novu, :api_key, @test_api_key)
+
+    on_exit(fn ->
+      Application.put_env(:novu, :domain, current_domain)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  describe "get_current_environment/0" do
+    test "creates a GET to /v1/environments/me", %{bypass: bypass} do
+      Bypass.expect(bypass, "GET", "/v1/environments/me", fn conn ->
+        novu_response(conn, 200, %{data: %{data: %{name: "example-name"}}})
+      end)
+
+      assert {:ok, _body} = Environments.get_current_environment()
+    end
+  end
+
+  describe "create_environment/2" do
+    test "creates a POST to /v1/environments", %{bypass: bypass} do
+      name = "example-name"
+
+      Bypass.expect(bypass, "POST", "/v1/environments", fn conn ->
+        assert %{"name" => ^name} = read_json_body(conn)
+        novu_response(conn, 201, %{data: %{data: %{name: "example-name"}}})
+      end)
+
+      assert {:ok, _body} = Environments.create_environment(name)
+    end
+
+    test "supports optional parentId", %{bypass: bypass} do
+      name = "example-name"
+      parent_id = "example-id"
+
+      Bypass.expect(bypass, "POST", "/v1/environments", fn conn ->
+        assert %{"name" => ^name, "parentId" => ^parent_id} = read_json_body(conn)
+        novu_response(conn, 201, %{data: %{data: %{name: name}}})
+      end)
+
+      assert {:ok, _body} = Environments.create_environment(name, parentId: parent_id)
+    end
+  end
+
+  describe "get_environments/0" do
+    test "creates a GET to /v1/environments", %{bypass: bypass} do
+      Bypass.expect(bypass, "GET", "/v1/environments", fn conn ->
+        novu_response(conn, 200, %{data: %{data: %{name: "example-name"}}})
+      end)
+
+      assert {:ok, _body} = Environments.get_environments()
+    end
+  end
+
+  describe "update_environment/2" do
+    test "creates a PUT to /v1/environments/{environmentId}", %{bypass: bypass} do
+      environment_id = "example-id"
+
+      Bypass.expect(bypass, "PUT", "/v1/environments/#{URI.encode(environment_id)}", fn conn ->
+        assert %{} = read_json_body(conn)
+        novu_response(conn, 200, %{data: %{data: %{name: "example-name"}}})
+      end)
+
+      assert {:ok, _body} = Environments.update_environment(environment_id)
+    end
+
+    test "supports optional name", %{bypass: bypass} do
+      name = "example-name"
+      environment_id = "example-id"
+
+      Bypass.expect(bypass, "PUT", "/v1/environments/#{URI.encode(environment_id)}", fn conn ->
+        assert %{"name" => ^name} = read_json_body(conn)
+        novu_response(conn, 200, %{data: %{data: %{name: name}}})
+      end)
+
+      assert {:ok, _body} = Environments.update_environment(environment_id, name: name)
+    end
+
+    test "supports optional identifier", %{bypass: bypass} do
+      identifier = "example-identifier"
+      environment_id = "example-id"
+
+      Bypass.expect(bypass, "PUT", "/v1/environments/#{URI.encode(environment_id)}", fn conn ->
+        assert %{"identifier" => ^identifier} = read_json_body(conn)
+        novu_response(conn, 200, %{data: %{data: %{identifier: identifier}}})
+      end)
+
+      assert {:ok, _body} = Environments.update_environment(environment_id, identifier: identifier)
+    end
+
+    test "supports optional parentId", %{bypass: bypass} do
+      parent_id = "example-parentId"
+      environment_id = "example-id"
+
+      Bypass.expect(bypass, "PUT", "/v1/environments/#{URI.encode(environment_id)}", fn conn ->
+        assert %{"parentId" => ^parent_id} = read_json_body(conn)
+        novu_response(conn, 200, %{data: %{data: %{parentId: parent_id}}})
+      end)
+
+      assert {:ok, _body} = Environments.update_environment(environment_id, parentId: parent_id)
+    end
+
+    test "supports optional inboundParseDomain", %{bypass: bypass} do
+      inbound_parse_domain = "dev.example"
+      environment_id = "example-id"
+
+      Bypass.expect(bypass, "PUT", "/v1/environments/#{URI.encode(environment_id)}", fn conn ->
+        assert %{"dns" => %{"inboundParseDomain" => ^inbound_parse_domain}} = read_json_body(conn)
+        novu_response(conn, 200, %{data: %{data: %{inboundParseDomain: inbound_parse_domain}}})
+      end)
+
+      assert {:ok, _body} = Environments.update_environment(environment_id, inboundParseDomain: inbound_parse_domain)
+    end
+  end
+
+  describe "get_api_keys/0" do
+    test "creates a GET to /v1/environments/api-keys", %{bypass: bypass} do
+      Bypass.expect(bypass, "GET", "/v1/environments/api-keys", fn conn ->
+        novu_response(conn, 200, %{data: %{data: %{name: "example-name"}}})
+      end)
+
+      assert {:ok, _body} = Environments.get_api_keys()
+    end
+  end
+
+  describe "regenerate_api_keys/0" do
+    test "creates a POST to /v1/environments/api-keys/regenerate", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/v1/environments/api-keys/regenerate", fn conn ->
+        assert %{} = read_json_body(conn)
+        novu_response(conn, 201, %{data: %{data: %{name: "example-name"}}})
+      end)
+
+      assert {:ok, _body} = Environments.regenerate_api_keys()
+    end
+  end
+end


### PR DESCRIPTION
- Adds `Novu.Environments` module with:
    - `get_current_environment/0`
    - `create_environment/2`
    - `get_environments/0`
    - `update_environment/2`
    - `get_api_keys/0`
    - `regenerate_api_keys/0`
- Add support to post requests with empty body using `post/2`