### PR TITLE
feat: set default maximum retry to zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ config :novu,
   domain: "domain",  # required: your domain
   wait_min: 1000,  # optional: the minimum time to retry a request is milliseconds (default: 1000)
   wait_max: 10_000,  # optional: the maximum time to retry a request is milliseconds (default: 10_000)
-  max_retries: 3,  # optional: the amount of retries in case of responses 408/429/500/502/503/504 (default: 3)
+  max_retries: 3,  # optional: the amount of retries in case of responses 408/429/500/502/503/504 (default: 0)
   retry_log_level: :warning  # optional: the log level to emit retry logs at. Can be set to false do disable logging (default: :warning)
 ```
 

--- a/lib/novu/http.ex
+++ b/lib/novu/http.ex
@@ -10,6 +10,8 @@ defmodule Novu.Http do
 
   @type response() :: {:ok, map()} | {:error, list() | :timeout | any()}
 
+  @max_retries 0
+
   @doc """
   Makes a `DELETE` request to Novu.
   """
@@ -81,7 +83,7 @@ defmodule Novu.Http do
 
   defp wait_min, do: Application.get_env(:novu, :wait_min, 1000)
   defp wait_max, do: Application.get_env(:novu, :wait_max, 10_000)
-  defp max_retries, do: Application.get_env(:novu, :max_retries, 3)
+  defp max_retries, do: Application.get_env(:novu, :max_retries, @max_retries)
   defp retry_log_level, do: Application.get_env(:novu, :retry_log_level, :warning)
 
   defp retry_delay_function(n) do

--- a/test/novu/http_test.exs
+++ b/test/novu/http_test.exs
@@ -25,6 +25,18 @@ defmodule Novu.HttpTest do
   end
 
   describe "build_req/1" do
+    test "default maximum retry should be zero", %{bypass: bypass} do
+      wait_min = 100
+      Application.put_env(:novu, :wait_min, wait_min)
+      Application.delete_env(:novu, :max_retries)
+
+      Bypass.expect_once(bypass, "GET", "/", fn conn ->
+        novu_response(conn, 500, %{data: %{error: "Internal Server Error"}})
+      end)
+
+      Http.get("/")
+    end
+
     test "creates a request with a minimum delay", %{bypass: bypass} do
       wait_min = 100
       Application.put_env(:novu, :wait_min, wait_min)


### PR DESCRIPTION
Set default retry config to be zero.
Add test to confirm that is indeed what happens.

Closes #33 